### PR TITLE
Implement issue #7

### DIFF
--- a/.anubis_root
+++ b/.anubis_root
@@ -1,3 +1,2 @@
-anubis_root(
-    output_dir = ".anubis-out"
-)
+# This file marks the root of an Anubis project.
+# Build outputs go to .anubis-build/ (intermediate) and .anubis-out/ (final).

--- a/src/anubis.rs
+++ b/src/anubis.rs
@@ -106,6 +106,18 @@ impl Anubis {
         Ok(anubis)
     }
 
+    /// Returns the build directory for intermediate build artifacts (object files, etc.)
+    /// Path: {root}/.anubis-build/{mode_name}
+    pub fn build_dir(&self, mode_name: &str) -> PathBuf {
+        self.root.join(".anubis-build").join(mode_name)
+    }
+
+    /// Returns the output directory for final build outputs (executables, etc.)
+    /// Path: {root}/.anubis-out/{mode_name}
+    pub fn out_dir(&self, mode_name: &str) -> PathBuf {
+        self.root.join(".anubis-out").join(mode_name)
+    }
+
     pub fn register_rule_typeinfo(&self, ti: RuleTypeInfo) -> anyhow::Result<()> {
         // Acquire write lock
         let mut rtis = write_lock(&self.rule_typeinfos)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,9 +91,17 @@ fn build(args: &BuildArgs) -> anyhow::Result<()> {
         }
     }
 
-    // Create anubis
+    // Find the project root by looking for .anubis_root file
     let cwd = std::env::current_dir()?;
-    let mut anubis = Arc::new(Anubis::new(cwd.to_owned())?);
+    let anubis_root_file = find_anubis_root(&cwd)?;
+    let project_root = anubis_root_file
+        .parent()
+        .ok_or_else(|| anyhow!("Could not get parent directory of .anubis_root"))?
+        .to_path_buf();
+    tracing::debug!("Found project root: {:?}", project_root);
+
+    // Create anubis with the discovered project root
+    let anubis = Arc::new(Anubis::new(project_root)?);
 
     // Build a target!
     let mode = AnubisTarget::new(&args.mode)?;

--- a/src/rules/cc_rules.rs
+++ b/src/rules/cc_rules.rs
@@ -494,11 +494,10 @@ fn build_cc_file(
                 &src_path
             )
         })?;
+        let mode_name = &ctx2.mode.as_ref().unwrap().name;
         let output_file = ctx2
             .anubis
-            .root
-            .join(".anubis-build")
-            .join(&ctx2.mode.as_ref().unwrap().name)
+            .build_dir(mode_name)
             .join(reldir)
             .join(src_filename)
             .with_extension("obj")
@@ -567,8 +566,8 @@ fn archive_static_library(
 
     // Compute output filepath
     let relpath = cpp_static_library.target.get_relative_dir();
-    let build_dir =
-        ctx.anubis.root.join(".anubis-build").join(&ctx.mode.as_ref().unwrap().name).join(relpath);
+    let mode_name = &ctx.mode.as_ref().unwrap().name;
+    let build_dir = ctx.anubis.build_dir(mode_name).join(relpath);
     ensure_directory(&build_dir)?;
 
     let output_file = build_dir.join(&cpp_static_library.name).with_extension("lib").slash_fix();
@@ -670,11 +669,10 @@ fn link_exe(
 
     // Compute output filepath
     let relpath = cpp.target.get_relative_dir();
+    let mode_name = &ctx.mode.as_ref().unwrap().name;
     let output_file = ctx
         .anubis
-        .root
-        .join(".anubis-out")
-        .join(&ctx.mode.as_ref().unwrap().name)
+        .out_dir(mode_name)
         .join(relpath)
         .join(&cpp.name)
         .with_extension("exe")

--- a/src/rules/nasm_rules.rs
+++ b/src/rules/nasm_rules.rs
@@ -118,11 +118,10 @@ fn nasm_assemble(nasm: Arc<NasmObjects>, ctx: Arc<JobContext>, src: &Path) -> an
     let relpath = pathdiff::diff_paths(&src, &ctx.anubis.root)
         .ok_or_else(|| anyhow_loc!("Could not relpath from [{:?}] to [{:?}]", &ctx.anubis.root, &src))?;
 
+    let mode_name = &ctx.mode.as_ref().unwrap().name;
     let object_path = ctx
         .anubis
-        .root
-        .join(".anubis-build")
-        .join(&ctx.mode.as_ref().unwrap().name)
+        .build_dir(mode_name)
         .join(relpath)
         .with_added_extension("obj") // result: foo.asm -> foo.asm.obj; avoid conflict with foo.c -> foo.obj
         .slash_fix();


### PR DESCRIPTION
- Add build_dir() and out_dir() helper methods to Anubis struct to standardize path calculation relative to the project root
- Update main.rs to use find_anubis_root() for proper root discovery instead of using the current working directory
- Replace manual path construction in cc_rules.rs and nasm_rules.rs with calls to the new helper methods
- Remove unused output_dir configuration from .anubis_root file

This ensures build outputs are always relative to the project root, regardless of the directory from which Anubis is invoked.

Fixes #7