### PR TITLE
Document backlog category in issue tracker

### DIFF
--- a/.claude/skills/dependency-mapping/SKILL.md
+++ b/.claude/skills/dependency-mapping/SKILL.md
@@ -18,12 +18,15 @@ The project board uses these status columns:
 
 | Status | Description |
 |--------|-------------|
+| **Backlog** | Future ideas or deferred work; not ready for action yet |
 | **Triage** | New issues not yet added to the project board |
 | **Needs Agent Review** | Issues ready for agent to review and categorize |
 | **Needs Human Review** | Agent has questions; waiting for human clarification |
 | **Ready to Implement** | Agent reviewed, wrote plan, no questions remaining |
 | **Needs Code Review** | Implementation in progress (has active branch) |
 | **Done** | Closed and completed (automatic via GitHub) |
+
+**Important:** Issues in **Backlog** should be **completely ignored** by this skill. These are deferred tasks that are not ready for dependency analysis.
 
 ## Purpose
 

--- a/.claude/skills/implementation/SKILL.md
+++ b/.claude/skills/implementation/SKILL.md
@@ -16,12 +16,15 @@ All issues are tracked on the **Anubis Issue Tracker** project board:
 
 | Status | Description |
 |--------|-------------|
+| **Backlog** | Future ideas or deferred work; not ready for action yet |
 | **Triage** | New issues not yet added to the project board |
 | **Needs Agent Review** | Issues ready for agent to review and categorize |
 | **Needs Human Review** | Agent has questions; waiting for human clarification |
 | **Ready to Implement** | Agent reviewed, wrote plan, no questions remaining |
 | **Needs Code Review** | Implementation in progress (has active branch) |
 | **Done** | Closed and completed (automatic via GitHub) |
+
+**Important:** Issues in **Backlog** should be **completely ignored** by this skill. These are deferred tasks that are not ready for implementation.
 
 ## Purpose
 

--- a/.claude/skills/issue-review/SKILL.md
+++ b/.claude/skills/issue-review/SKILL.md
@@ -16,12 +16,15 @@ All issues are tracked on the **Anubis Issue Tracker** project board:
 
 | Status | Description |
 |--------|-------------|
+| **Backlog** | Future ideas or deferred work; not ready for action yet |
 | **Triage** | New issues not yet added to the project board |
 | **Needs Agent Review** | Issues ready for agent to review and categorize |
 | **Needs Human Review** | Agent has questions; waiting for human clarification |
 | **Ready to Implement** | Agent reviewed, wrote plan, no questions remaining |
 | **Needs Code Review** | Implementation in progress (has active branch) |
 | **Done** | Closed and completed (automatic via GitHub) |
+
+**Important:** Issues in **Backlog** should be **completely ignored** by this skill. These are deferred tasks that are not ready for review. Do not triage, categorize, or write implementation plans for Backlog issues.
 
 ## Workflow Overview
 

--- a/.claude/skills/kanban-management/SKILL.md
+++ b/.claude/skills/kanban-management/SKILL.md
@@ -16,16 +16,19 @@ The **Anubis Issue Tracker** project board is already created and configured:
 
 ## Board Status Workflow
 
-The project board uses these six status columns:
+The project board uses these seven status columns:
 
 | Status | Description |
 |--------|-------------|
+| **Backlog** | Future ideas or deferred work; not ready for action yet |
 | **Triage** | New issues not yet added to the project board |
 | **Needs Agent Review** | Issues ready for agent to review and categorize |
 | **Needs Human Review** | Agent has questions; waiting for human clarification |
 | **Ready to Implement** | Agent reviewed, wrote plan, no questions remaining |
 | **Needs Code Review** | Implementation in progress (has active branch) |
 | **Done** | Closed and completed (automatic via GitHub) |
+
+**Important:** Issues in **Backlog** should be **completely ignored** by all skills. These are tasks that have been captured so they won't be forgotten, but are not ready for action. They will be moved to Triage or Needs Agent Review when they are ready to be worked on.
 
 ## Workflow Overview
 


### PR DESCRIPTION
Document the Backlog column as a place for future ideas and deferred work. All skills should completely ignore issues in Backlog status.