### PR TITLE
issue 47 - Create syntax highlighter for ANUBIS files

### DIFF
--- a/tools/anubis-vscode/README.md
+++ b/tools/anubis-vscode/README.md
@@ -1,0 +1,82 @@
+# Anubis Syntax Highlighting for VSCode
+
+Provides syntax highlighting for ANUBIS build configuration files using the Papyrus DSL.
+
+## Features
+
+- Syntax highlighting for ANUBIS configuration files
+- Automatic language detection for files named `ANUBIS`
+- Bracket matching and auto-closing
+- Comment toggling with `#`
+
+## Highlighted Elements
+
+| Element | Examples |
+|---------|----------|
+| **Comments** | `# This is a comment` |
+| **Strings** | `"hello"`, `"path/to/file.cpp"` |
+| **Keywords** | `select`, `default`, `glob`, `includes`, `excludes` |
+| **Built-in Functions** | `RelPath()`, `RelPaths()` |
+| **Rule Types** | `mode`, `toolchain`, `cc_binary`, `cc_static_library`, `cpp_binary`, `cpp_static_library`, `nasm_objects`, `nasm_static_library` |
+| **Type Constructors** | `CcToolchain`, `NasmToolchain` |
+| **Constants** | `true`, `false`, `_` (wildcard) |
+| **Numbers** | `42`, `-3.14`, `1e10` |
+| **Operators** | `=`, `=>`, `+`, `\|` |
+
+## Installation
+
+### From Source (Development)
+
+1. Copy or symlink this folder to your VSCode extensions directory:
+   - **Windows**: `%USERPROFILE%\.vscode\extensions\anubis-syntax`
+   - **macOS/Linux**: `~/.vscode/extensions/anubis-syntax`
+
+2. Reload VSCode
+
+### Manual Steps
+
+```bash
+# Linux/macOS
+ln -s /path/to/anubis/tools/anubis-vscode ~/.vscode/extensions/anubis-syntax
+
+# Windows (PowerShell as Admin)
+New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.vscode\extensions\anubis-syntax" -Target "C:\path\to\anubis\tools\anubis-vscode"
+```
+
+## Example
+
+```papyrus
+# Build configuration for a C++ binary
+cc_binary(
+    name = "my_app",
+    lang = "cpp",
+    srcs = glob(["src/*.cpp"]),
+    deps = ["//libs/mylib:mylib"],
+    compiler_flags = ["-O2", "-Wall"] + select(
+        (target_platform) => {
+            (windows) = ["-DWIN32"],
+            (linux) = ["-DLINUX"],
+            default = [],
+        }
+    ),
+)
+```
+
+## File Associations
+
+The extension automatically activates for files named `ANUBIS`. To manually set the language mode:
+
+1. Open the file in VSCode
+2. Click on the language indicator in the status bar (bottom right)
+3. Select "Papyrus" or "ANUBIS"
+
+## Development
+
+The extension uses TextMate grammars defined in `syntaxes/papyrus.tmLanguage.json`. To modify the syntax highlighting:
+
+1. Edit `syntaxes/papyrus.tmLanguage.json`
+2. Reload VSCode window (`Ctrl+Shift+P` → "Developer: Reload Window")
+
+## License
+
+MIT

--- a/tools/anubis-vscode/language-configuration.json
+++ b/tools/anubis-vscode/language-configuration.json
@@ -1,0 +1,32 @@
+{
+    "comments": {
+        "lineComment": "#"
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "\"", "close": "\"", "notIn": ["string"] }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""]
+    ],
+    "folding": {
+        "markers": {
+            "start": "^\\s*[a-zA-Z_][a-zA-Z0-9_]*\\s*\\(",
+            "end": "^\\s*\\)"
+        }
+    },
+    "indentationRules": {
+        "increaseIndentPattern": "^.*[\\(\\[\\{]\\s*$",
+        "decreaseIndentPattern": "^\\s*[\\)\\]\\}]"
+    }
+}

--- a/tools/anubis-vscode/package.json
+++ b/tools/anubis-vscode/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "anubis-syntax",
+    "displayName": "Anubis (Papyrus DSL)",
+    "description": "Syntax highlighting for ANUBIS build configuration files using the Papyrus DSL",
+    "version": "0.1.0",
+    "publisher": "anubis",
+    "engines": {
+        "vscode": "^1.60.0"
+    },
+    "categories": [
+        "Programming Languages"
+    ],
+    "contributes": {
+        "languages": [
+            {
+                "id": "papyrus",
+                "aliases": [
+                    "Papyrus",
+                    "ANUBIS"
+                ],
+                "filenames": [
+                    "ANUBIS"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "papyrus",
+                "scopeName": "source.papyrus",
+                "path": "./syntaxes/papyrus.tmLanguage.json"
+            }
+        ]
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/forrestthewoods/anubis"
+    },
+    "license": "MIT"
+}

--- a/tools/anubis-vscode/syntaxes/papyrus.tmLanguage.json
+++ b/tools/anubis-vscode/syntaxes/papyrus.tmLanguage.json
@@ -1,0 +1,167 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Papyrus",
+    "scopeName": "source.papyrus",
+    "patterns": [
+        { "include": "#comments" },
+        { "include": "#strings" },
+        { "include": "#keywords" },
+        { "include": "#builtins" },
+        { "include": "#rule-types" },
+        { "include": "#type-constructors" },
+        { "include": "#constants" },
+        { "include": "#numbers" },
+        { "include": "#operators" },
+        { "include": "#identifiers" },
+        { "include": "#punctuation" }
+    ],
+    "repository": {
+        "comments": {
+            "patterns": [
+                {
+                    "name": "comment.line.number-sign.papyrus",
+                    "match": "#.*$"
+                }
+            ]
+        },
+        "strings": {
+            "patterns": [
+                {
+                    "name": "string.quoted.double.papyrus",
+                    "begin": "\"",
+                    "end": "\"",
+                    "patterns": [
+                        {
+                            "name": "constant.character.escape.papyrus",
+                            "match": "\\\\[\"\\\\bnfrt]|\\\\u[a-fA-F0-9]{4}"
+                        }
+                    ]
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "name": "keyword.control.papyrus",
+                    "match": "\\b(select|default)\\b"
+                },
+                {
+                    "name": "keyword.other.papyrus",
+                    "match": "\\b(glob|includes|excludes)\\b"
+                }
+            ]
+        },
+        "builtins": {
+            "patterns": [
+                {
+                    "name": "support.function.papyrus",
+                    "match": "\\b(RelPath|RelPaths)\\b"
+                }
+            ]
+        },
+        "rule-types": {
+            "patterns": [
+                {
+                    "name": "entity.name.type.rule.papyrus",
+                    "match": "\\b(mode|toolchain|cc_binary|cc_static_library|cpp_binary|cpp_static_library|nasm_objects|nasm_static_library)\\b"
+                }
+            ]
+        },
+        "type-constructors": {
+            "patterns": [
+                {
+                    "name": "entity.name.type.constructor.papyrus",
+                    "match": "\\b(CcToolchain|NasmToolchain)\\b"
+                }
+            ]
+        },
+        "constants": {
+            "patterns": [
+                {
+                    "name": "constant.language.boolean.papyrus",
+                    "match": "\\b(true|false)\\b"
+                },
+                {
+                    "name": "constant.language.wildcard.papyrus",
+                    "match": "\\b_\\b"
+                }
+            ]
+        },
+        "numbers": {
+            "patterns": [
+                {
+                    "name": "constant.numeric.papyrus",
+                    "match": "-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?"
+                }
+            ]
+        },
+        "operators": {
+            "patterns": [
+                {
+                    "name": "keyword.operator.arrow.papyrus",
+                    "match": "=>"
+                },
+                {
+                    "name": "keyword.operator.assignment.papyrus",
+                    "match": "="
+                },
+                {
+                    "name": "keyword.operator.concatenation.papyrus",
+                    "match": "\\+"
+                },
+                {
+                    "name": "keyword.operator.pipe.papyrus",
+                    "match": "\\|"
+                }
+            ]
+        },
+        "identifiers": {
+            "patterns": [
+                {
+                    "name": "variable.parameter.papyrus",
+                    "match": "\\b[a-zA-Z_][a-zA-Z0-9_\\-\\.]*(?=\\s*=)"
+                },
+                {
+                    "name": "variable.other.papyrus",
+                    "match": "\\b[a-zA-Z_][a-zA-Z0-9_\\-\\.]*\\b"
+                }
+            ]
+        },
+        "punctuation": {
+            "patterns": [
+                {
+                    "name": "punctuation.definition.block.begin.papyrus",
+                    "match": "\\{"
+                },
+                {
+                    "name": "punctuation.definition.block.end.papyrus",
+                    "match": "\\}"
+                },
+                {
+                    "name": "punctuation.definition.array.begin.papyrus",
+                    "match": "\\["
+                },
+                {
+                    "name": "punctuation.definition.array.end.papyrus",
+                    "match": "\\]"
+                },
+                {
+                    "name": "punctuation.definition.parameters.begin.papyrus",
+                    "match": "\\("
+                },
+                {
+                    "name": "punctuation.definition.parameters.end.papyrus",
+                    "match": "\\)"
+                },
+                {
+                    "name": "punctuation.separator.papyrus",
+                    "match": ","
+                },
+                {
+                    "name": "punctuation.separator.colon.papyrus",
+                    "match": ":"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Create a TextMate grammar-based VSCode extension that provides syntax highlighting for ANUBIS build configuration files using the Papyrus DSL.

Highlights comments, strings, keywords (select, glob, default), built-in functions (RelPath, RelPaths), rule types (cc_binary, cc_static_library, mode, toolchain, etc.), operators, and constants.