### PR TITLE
issue 65 - Convert anyhow! to anyhow_loc! and bail! to bail_loc!

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,4 @@
+use crate::{anyhow_loc, function_name};
 use anyhow::Result;
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -35,7 +36,7 @@ impl std::str::FromStr for LogLevel {
             "info" => Ok(LogLevel::Info),
             "debug" => Ok(LogLevel::Debug),
             "trace" => Ok(LogLevel::Trace),
-            _ => Err(anyhow::anyhow!(
+            _ => Err(anyhow_loc!(
                 "Invalid log level '{}'. Valid options are: error, warn, info, debug, trace",
                 s
             )),

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ mod papyrus_tests;
 mod util_tests;
 
 use anubis::*;
-use anyhow::{anyhow, bail};
 use dashmap::DashMap;
 use install_toolchains::*;
 use job_system::*;
@@ -119,7 +118,7 @@ fn dump(args: &DumpArgs) -> anyhow::Result<()> {
     let anubis_root_file = find_anubis_root(&cwd)?;
     let project_root = anubis_root_file
         .parent()
-        .ok_or_else(|| anyhow!("Could not get parent directory of .anubis_root"))?
+        .ok_or_else(|| anyhow_loc!("Could not get parent directory of .anubis_root"))?
         .to_path_buf();
 
     // Create anubis
@@ -172,7 +171,7 @@ fn build(args: &BuildArgs, workers: Option<usize>) -> anyhow::Result<()> {
     let anubis_root_file = find_anubis_root(&cwd)?;
     let project_root = anubis_root_file
         .parent()
-        .ok_or_else(|| anyhow!("Could not get parent directory of .anubis_root"))?
+        .ok_or_else(|| anyhow_loc!("Could not get parent directory of .anubis_root"))?
         .to_path_buf();
     tracing::debug!("Found project root: {:?}", project_root);
 
@@ -215,7 +214,7 @@ fn run(args: &RunArgs, workers: Option<usize>) -> anyhow::Result<()> {
     let anubis_root_file = find_anubis_root(&cwd)?;
     let project_root = anubis_root_file
         .parent()
-        .ok_or_else(|| anyhow!("Could not get parent directory of .anubis_root"))?
+        .ok_or_else(|| anyhow_loc!("Could not get parent directory of .anubis_root"))?
         .to_path_buf();
     tracing::debug!("Found project root: {:?}", project_root);
 
@@ -250,7 +249,7 @@ fn run(args: &RunArgs, workers: Option<usize>) -> anyhow::Result<()> {
 
     // Verify the executable exists
     if !exe_path.exists() {
-        bail!(
+        bail_loc!(
             "Executable not found at {:?}. Build may have failed or target is not an executable.",
             exe_path
         );

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use crate::{anyhow_loc, function_name};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -103,7 +104,7 @@ pub fn create_directory_symlink(target: &Path, link_path: &Path) -> anyhow::Resu
     }
 
     symlink_dir(target, link_path).map_err(|e| {
-        anyhow::anyhow!(
+        anyhow_loc!(
             "Failed to create symlink from {} to {}\n\n\
              On Windows, creating symlinks requires either:\n\
              1. Developer Mode enabled (Settings > Update & Security > For Developers)\n\


### PR DESCRIPTION
Replace all uses of anyhow! and bail! with their location-aware variants anyhow_loc! and bail_loc! which include file, function name, and line number in error messages for better debugging.

Files modified:
- main.rs: Convert 4 occurrences
- job_system.rs: Convert 11 occurrences
- install_toolchains.rs: Convert 42 occurrences
- util.rs: Convert 1 occurrence
- logging.rs: Convert 1 occurrence

Added necessary imports for anyhow_loc, bail_loc, and function_name macros in all affected files.