### PR TITLE
issue 81 - diamond dependency example

### DIFF
--- a/examples/nested_staticlib_cpp/ANUBIS
+++ b/examples/nested_staticlib_cpp/ANUBIS
@@ -1,0 +1,48 @@
+# Nested static library example demonstrating diamond dependency pattern:
+#
+#       main
+#      /    \
+#    foo    bar
+#      \    /
+#       util
+#
+# Both foo and bar depend on util, but util should only be built once.
+# This verifies that issue #18's duplicate prevention works correctly.
+
+cc_binary(
+    name = "main",
+    lang = "cpp",
+    srcs = [ RelPath("src/main.cpp") ],
+    deps = [
+        "//examples/nested_staticlib_cpp:foo",
+        "//examples/nested_staticlib_cpp:bar",
+    ],
+)
+
+cc_static_library(
+    name = "foo",
+    lang = "cpp",
+    srcs = [ RelPath("src/foo.cpp") ],
+    public_include_dirs = [ RelPath("include") ],
+    deps = [
+        "//examples/nested_staticlib_cpp:util",
+    ],
+)
+
+cc_static_library(
+    name = "bar",
+    lang = "cpp",
+    srcs = [ RelPath("src/bar.cpp") ],
+    public_include_dirs = [ RelPath("include") ],
+    deps = [
+        "//examples/nested_staticlib_cpp:util",
+    ],
+)
+
+cc_static_library(
+    name = "util",
+    lang = "cpp",
+    srcs = [ RelPath("src/util.cpp") ],
+    public_include_dirs = [ RelPath("include") ],
+    deps = [],
+)

--- a/examples/nested_staticlib_cpp/include/bar/bar.h
+++ b/examples/nested_staticlib_cpp/include/bar/bar.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace bar {
+    void do_bar();
+}

--- a/examples/nested_staticlib_cpp/include/foo/foo.h
+++ b/examples/nested_staticlib_cpp/include/foo/foo.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace foo {
+    void do_foo();
+}

--- a/examples/nested_staticlib_cpp/include/util/util.h
+++ b/examples/nested_staticlib_cpp/include/util/util.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace util {
+    // Shared utility function used by both foo and bar
+    void print_message(const char* source);
+}

--- a/examples/nested_staticlib_cpp/src/bar.cpp
+++ b/examples/nested_staticlib_cpp/src/bar.cpp
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+#include <bar/bar.h>
+#include <util/util.h>
+
+namespace bar {
+    void do_bar() {
+        printf("bar::do_bar\n");
+        util::print_message("bar");
+    }
+}

--- a/examples/nested_staticlib_cpp/src/foo.cpp
+++ b/examples/nested_staticlib_cpp/src/foo.cpp
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+#include <foo/foo.h>
+#include <util/util.h>
+
+namespace foo {
+    void do_foo() {
+        printf("foo::do_foo\n");
+        util::print_message("foo");
+    }
+}

--- a/examples/nested_staticlib_cpp/src/main.cpp
+++ b/examples/nested_staticlib_cpp/src/main.cpp
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+#include <foo/foo.h>
+#include <bar/bar.h>
+
+int main() {
+    printf("=== Nested Static Library Example ===\n");
+    printf("Diamond dependency: main -> foo, bar -> util\n\n");
+
+    foo::do_foo();
+    bar::do_bar();
+
+    printf("\nDone!\n");
+    return 0;
+}

--- a/examples/nested_staticlib_cpp/src/util.cpp
+++ b/examples/nested_staticlib_cpp/src/util.cpp
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+#include <util/util.h>
+
+namespace util {
+    void print_message(const char* source) {
+        printf("util::print_message called from %s\n", source);
+    }
+}


### PR DESCRIPTION
Create an example demonstrating the diamond dependency pattern where main depends on foo and bar, and both foo and bar depend on util. This tests that issue #18's duplicate prevention works correctly - util should only be built once despite being referenced by multiple libraries.

Closes #81