### PR TITLE
issue 91 - Add FullVerbose logging for subcommand output

### DIFF
--- a/src/rules/cc_rules.rs
+++ b/src/rules/cc_rules.rs
@@ -5,7 +5,7 @@
 
 use crate::anubis::{self, AnubisTarget, JobCacheKey, RuleExt};
 use crate::{job_system::*, toolchain};
-use crate::rules::rule_utils::{ensure_directory, ensure_directory_for_file, run_command};
+use crate::rules::rule_utils::{ensure_directory, ensure_directory_for_file, run_command_verbose};
 use crate::util::SlashFix;
 use crate::{anubis::RuleTypename, Anubis, Rule, RuleTypeInfo};
 use anyhow::Context;
@@ -571,10 +571,11 @@ fn build_cc_file(
 
         // run the command
         let compiler = ctx2.get_compiler(lang)?;
+        let verbose = ctx2.anubis.verbose_tools;
         let (output, compile_duration) = {
             let _span = tracing::info_span!("compile", file = %src2).entered();
             let compile_start = std::time::Instant::now();
-            let output = run_command(compiler, &args)?;
+            let output = run_command_verbose(compiler, &args, verbose)?;
             (output, compile_start.elapsed())
         };
 
@@ -675,9 +676,10 @@ fn archive_static_library(
 
     // run the command
     let archiver = ctx.get_archiver(lang)?;
+    let verbose = ctx.anubis.verbose_tools;
     let output = {
         let _span = tracing::info_span!("archive", target = %name).entered();
-        run_command(archiver, &args)?
+        run_command_verbose(archiver, &args, verbose)?
     };
 
     if output.status.success() {
@@ -838,10 +840,11 @@ fn link_exe(
 
     // run the command
     let linker = ctx.get_linker(lang)?;
+    let verbose = ctx.anubis.verbose_tools;
     let (output, link_duration) = {
         let _span = tracing::info_span!("link", target = %name).entered();
         let link_start = std::time::Instant::now();
-        let output = run_command(linker, &args)?;
+        let output = run_command_verbose(linker, &args, verbose)?;
         (output, link_start.elapsed())
     };
 

--- a/src/rules/nasm_rules.rs
+++ b/src/rules/nasm_rules.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::anubis::{self, AnubisTarget};
 use crate::job_system::*;
-use crate::rules::rule_utils::{ensure_directory, ensure_directory_for_file, run_command};
+use crate::rules::rule_utils::{ensure_directory, ensure_directory_for_file, run_command_verbose};
 use crate::util::SlashFix;
 use crate::{anubis::RuleTypename, Anubis, Rule, RuleTypeInfo};
 use crate::{anyhow_loc, bail_loc, bail_loc_if, function_name};
@@ -195,7 +195,8 @@ fn nasm_assemble(nasm: Arc<NasmObjects>, ctx: Arc<JobContext>, src: &Path) -> an
     args.push("-o".to_owned());
     args.push(object_path.to_string_lossy().into());
 
-    let output = run_command(assembler, &args)?;
+    let verbose = ctx.anubis.verbose_tools;
+    let output = run_command_verbose(assembler, &args, verbose)?;
 
     if output.status.success() {
         Ok(JobOutcome::Success(Arc::new(CcObjectArtifact { object_path })))
@@ -303,7 +304,8 @@ fn nasm_assemble_static_lib(
     args.push("-o".to_owned());
     args.push(object_path.to_string_lossy().into());
 
-    let output = run_command(assembler, &args)?;
+    let verbose = ctx.anubis.verbose_tools;
+    let output = run_command_verbose(assembler, &args, verbose)?;
 
     if output.status.success() {
         Ok(JobOutcome::Success(Arc::new(CcObjectArtifact { object_path })))
@@ -394,7 +396,8 @@ fn archive_nasm_static_library(
     args.push(format!("@{}", response_filepath.to_string_lossy()));
 
     // Run the archiver command
-    let output = run_command(archiver, &args)?;
+    let verbose = ctx.anubis.verbose_tools;
+    let output = run_command_verbose(archiver, &args, verbose)?;
 
     if output.status.success() {
         Ok(JobOutcome::Success(Arc::new(CcObjectArtifact {

--- a/src/rules/zig_rules.rs
+++ b/src/rules/zig_rules.rs
@@ -6,8 +6,8 @@
 use crate::anubis::{self, AnubisTarget};
 use crate::cc_rules;
 use crate::job_system::*;
-use crate::rules::{CcBuildOutput, CcLanguage, rule_utils};
-use crate::rules::rule_utils::{ensure_directory, run_command};
+use crate::rules::{CcBuildOutput, CcLanguage};
+use crate::rules::rule_utils::{ensure_directory, run_command_verbose};
 use crate::util::SlashFix;
 use crate::{anubis::RuleTypename, Anubis, Rule, RuleTypeInfo};
 use crate::{anyhow_loc, bail_loc, function_name};
@@ -133,7 +133,8 @@ fn build_zig_glibc(zig_glibc: Arc<ZigGlibc>, job: Job) -> anyhow::Result<JobOutc
         src_file.to_string_lossy().into(),
     ];
 
-    let output = rule_utils::run_command(&toolchain.zig.compiler, &args)?;
+    let verbose = job.ctx.anubis.verbose_tools;
+    let output = run_command_verbose(&toolchain.zig.compiler, &args, verbose)?;
 
     if output.status.success() {
         // zig emits all logs to stderr


### PR DESCRIPTION
When --log-level fullverbose is used, this change now logs the stdout and stderr output from all external commands (compiler, linker, archiver, etc.) at info level, making it easier to debug build issues.

Previously, FullVerbose only passed verbose flags like -v to tools but didn't display their output. Now the output is captured and logged.

Fixes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verbose output mode for build commands. When enabled, get detailed logs from all compilation and archiving tools during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->