### PR TITLE
issue 98 - build_cc_binary should have a per-platform file extension

### DIFF
--- a/src/rules/cc_rules.rs
+++ b/src/rules/cc_rules.rs
@@ -819,17 +819,13 @@ fn link_exe(
     // Compute output filepath with platform-appropriate extension
     let relpath = target.get_relative_dir();
     let mode_name = &mode.name;
-    let output_path = ctx
+    let output_file = ctx
         .anubis
         .out_dir(mode_name)
         .join(relpath)
-        .join(name);
-    let output_file = if target_platform == "windows" {
-        output_path.with_extension("exe")
-    } else {
-        // Linux/macOS executables have no extension
-        output_path
-    }.slash_fix();
+        .join(name)
+        .with_extension(if target_platform == "windows" { "exe" } else { "" })
+        .slash_fix();
     ensure_directory_for_file(&output_file)?;
 
     // Add output file argument


### PR DESCRIPTION
Changes link_exe to only append .exe extension when target_platform is "windows". Linux and macOS executables are output without an extension.

Fixes #98