### PR TITLE
Allow Anubis build to specify target options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ struct BuildArgs {
     #[arg(short, long)]
     mode: String,
 
-    #[arg(short, long)]
+    #[arg(short, long, visible_alias = "target")]
     targets: Vec<String>,
 }
 


### PR DESCRIPTION
Allows users to use either --target or --targets when specifying build targets, improving consistency with other commands like 'run' which use the singular form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an alternative `--target` flag as a shorthand alias for the existing `--targets` command-line option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->