### PR TITLE
Make toolchain components optional with better error messages

### DIFF
--- a/src/rules/cc_rules.rs
+++ b/src/rules/cc_rules.rs
@@ -217,8 +217,18 @@ impl<'a> CcContextExt<'a> for Arc<JobContext> {
     fn get_cc_toolchain(&'a self, lang: CcLanguage) -> anyhow::Result<&'a crate::toolchain::CcToolchain> {
         let toolchain = self.get_toolchain()?;
         match lang {
-            CcLanguage::C => Ok(&toolchain.c),
-            CcLanguage::Cpp => Ok(&toolchain.cpp),
+            CcLanguage::C => toolchain.c.as_ref().ok_or_else(|| {
+                anyhow_loc!(
+                    "C toolchain not configured in toolchain '{}'. Add a 'c' field to the toolchain definition.",
+                    toolchain.name
+                )
+            }),
+            CcLanguage::Cpp => toolchain.cpp.as_ref().ok_or_else(|| {
+                anyhow_loc!(
+                    "C++ toolchain not configured in toolchain '{}'. Add a 'cpp' field to the toolchain definition.",
+                    toolchain.name
+                )
+            }),
         }
     }
 

--- a/src/rules/zig_rules.rs
+++ b/src/rules/zig_rules.rs
@@ -78,6 +78,12 @@ fn build_zig_glibc(zig_glibc: Arc<ZigGlibc>, job: Job) -> anyhow::Result<JobOutc
     // setup
     let mode = job.ctx.mode.as_ref().ok_or_else(|| anyhow_loc!("No mode specified"))?;
     let toolchain = job.ctx.toolchain.as_ref().ok_or_else(|| anyhow_loc!("No toolchain specified"))?.as_ref();
+    let zig_toolchain = toolchain.zig.as_ref().ok_or_else(|| {
+        anyhow_loc!(
+            "Zig toolchain not configured in toolchain '{}'. Add a 'zig' field to the toolchain definition.",
+            toolchain.name
+        )
+    })?;
 
     let build_dir = job
         .ctx
@@ -146,7 +152,7 @@ fn build_zig_glibc(zig_glibc: Arc<ZigGlibc>, job: Job) -> anyhow::Result<JobOutc
     args.push(src_file.to_string_lossy().into());
 
     let verbose = job.ctx.anubis.verbose_tools;
-    let output = run_command_verbose(&toolchain.zig.compiler, &args, verbose)?;
+    let output = run_command_verbose(&zig_toolchain.compiler, &args, verbose)?;
 
     if output.status.success() {
         // zig emits all logs to stderr

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -17,10 +17,18 @@ use std::path::PathBuf;
 #[serde(deny_unknown_fields)]
 pub struct Toolchain {
     pub name: String,
-    pub c: CcToolchain,
-    pub cpp: CcToolchain,
-    pub nasm: NasmToolchain,
-    pub zig: ZigToolchain,
+
+    #[serde(default)]
+    pub c: Option<CcToolchain>,
+
+    #[serde(default)]
+    pub cpp: Option<CcToolchain>,
+
+    #[serde(default)]
+    pub nasm: Option<NasmToolchain>,
+
+    #[serde(default)]
+    pub zig: Option<ZigToolchain>,
 
     /// Mode target for building host tools (e.g., //mode:win_release).
     /// This mode is used when building tools that run on the host platform,


### PR DESCRIPTION
## Summary
This change makes all toolchain components (C, C++, NASM, and Zig) optional in the toolchain configuration, while providing clear and actionable error messages when a required toolchain is missing.

## Key Changes
- **Toolchain struct**: Changed all toolchain fields (`c`, `cpp`, `nasm`, `zig`) from required to `Option<T>` with `#[serde(default)]` attribute
- **CC rules**: Updated `get_cc_toolchain()` to check for `None` and return descriptive errors indicating which language toolchain is missing and how to configure it
- **NASM rules**: Added validation checks in three functions (`nasm_assemble`, `nasm_assemble_static_lib`, `archive_nasm_static_library`) to ensure NASM toolchain is configured before use
- **Zig rules**: Added validation check in `build_zig_glibc()` to ensure Zig toolchain is configured before use

## Implementation Details
- All validation uses the `anyhow_loc!` macro to provide location information in error messages
- Error messages follow a consistent pattern: `"<Language> toolchain not configured in toolchain '<name>'. Add a '<field>' field to the toolchain definition."`
- This allows users to configure only the toolchain components they need for their project
- Errors are caught early with helpful guidance on how to fix the configuration

https://claude.ai/code/session_012rX7yZhETqyNnaXgdZTB44