### PR TITLE
Rename host variables to build variables for clarity

### DIFF
--- a/.claude/skills/anubis-windows-commands/SKILL.md
+++ b/.claude/skills/anubis-windows-commands/SKILL.md
@@ -48,7 +48,7 @@ MSYS_NO_PATHCONV=1 cargo run --release -- build --workers 16 -l debug --mode //m
 
 Apply `MSYS_NO_PATHCONV=1` when ALL of these conditions are true:
 
-1. **Platform is Windows** (`host_platform` is `windows`)
+1. **Platform is Windows** (`build_platform` is `windows`)
 2. **Shell is Git Bash** (MSYS/MinGW environment - check for `MSYSTEM` env var or `/usr/bin/bash` path)
 3. **Command contains `//` paths** (Anubis target notation)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,9 @@ Mode variables (defined in `mode/ANUBIS`):
 - `target_platform`: `windows`, `linux`
 - `target_arch`: `x64`, `arm64`
 
-Auto-injected host variables:
-- `host_platform`: Current OS (`windows`, `linux`, `macos`)
-- `host_arch`: Current architecture (`x64`, `arm64`)
+Auto-injected build variables:
+- `build_platform`: Current OS (`windows`, `linux`, `macos`)
+- `build_arch`: Current architecture (`x64`, `arm64`)
 
 ## Rule Types
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ mode(
 toolchain(
     name = "default",
     cpp = CcToolchain(
-        compiler = select((host_platform, host_arch) => {
+        compiler = select((build_platform, build_arch) => {
             (windows, x64) = RelPath("llvm/x86_64-pc-windows-msvc/bin/clang++.exe")
         }),
         compiler_flags = select((target_platform, target_arch) => {

--- a/src/anubis.rs
+++ b/src/anubis.rs
@@ -424,18 +424,18 @@ impl Anubis {
             m.target = mode_target.clone();
         }
 
-        // inject host platform
+        // inject build platform (the platform we're building on)
         if let Ok(m) = &mut mode {
             // ex: windows, linux, macos
-            m.vars.insert("host_platform".into(), std::env::consts::OS.into());
+            m.vars.insert("build_platform".into(), std::env::consts::OS.into());
 
             // we use our own architecture naming scheme
-            let host_arch = match std::env::consts::ARCH {
+            let build_arch = match std::env::consts::ARCH {
                 "x86_64" => "x64",
                 "aarch64" => "arm64",
-                default => bail_loc!("Unsupported host architecture {}", std::env::consts::ARCH),
+                default => bail_loc!("Unsupported build architecture {}", std::env::consts::ARCH),
             };
-            m.vars.insert("host_arch".into(), host_arch.into());
+            m.vars.insert("build_arch".into(), build_arch.into());
         }
 
         // Arcify and store mode

--- a/src/rules/cmd_rules.rs
+++ b/src/rules/cmd_rules.rs
@@ -114,21 +114,21 @@ fn build_anubis_cmd(cmd: Arc<AnubisCmd>, mut job: Job) -> anyhow::Result<JobOutc
         .as_ref()
         .ok_or_else(|| anyhow_loc!("Cannot build AnubisCmd without a toolchain"))?;
 
-    // Get host mode for building the tool from the toolchain configuration.
-    let host_mode = job.ctx.anubis.get_mode(&toolchain.host_mode)?;
+    // Get build mode for building the tool from the toolchain configuration.
+    let build_mode = job.ctx.anubis.get_mode(&toolchain.build_mode)?;
 
-    // Create a new context with host mode for building the tool
-    let host_toolchain_target = AnubisTarget::new("//toolchains:default")?;
-    let host_toolchain = job.ctx.anubis.get_toolchain(host_mode.clone(), &host_toolchain_target)?;
+    // Create a new context with build mode for building the tool
+    let build_toolchain_target = AnubisTarget::new("//toolchains:default")?;
+    let build_toolchain = job.ctx.anubis.get_toolchain(build_mode.clone(), &build_toolchain_target)?;
 
-    let host_ctx = Arc::new(JobContext {
+    let build_ctx = Arc::new(JobContext {
         anubis: job.ctx.anubis.clone(),
         job_system: job.ctx.job_system.clone(),
-        mode: Some(host_mode),
-        toolchain: Some(host_toolchain),
+        mode: Some(build_mode),
+        toolchain: Some(build_toolchain),
     });
 
-    let tool_job_id = job.ctx.anubis.build_rule(&cmd.tool, &host_ctx)?;
+    let tool_job_id = job.ctx.anubis.build_rule(&cmd.tool, &build_ctx)?;
 
     // Create the job that spawns command child jobs after the tool is built
     let cmd2 = cmd.clone();

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -22,10 +22,10 @@ pub struct Toolchain {
     pub nasm: NasmToolchain,
     pub zig: ZigToolchain,
 
-    /// Mode target for building host tools (e.g., //mode:win_release).
-    /// This mode is used when building tools that run on the host platform,
+    /// Mode target for building build tools (e.g., //mode:win_release).
+    /// This mode is used when building tools that run on the build platform,
     /// such as those used by `anubis_cmd` rules during cross-compilation.
-    pub host_mode: AnubisTarget,
+    pub build_mode: AnubisTarget,
 
     #[serde(skip_deserializing)]
     pub target: AnubisTarget,

--- a/toolchains/ANUBIS
+++ b/toolchains/ANUBIS
@@ -21,26 +21,26 @@ install_toolchains(
 
 toolchain(
     name = "default",
-    host_mode = select(
-        (host_platform) => {
+    build_mode = select(
+        (build_platform) => {
             (windows) = Target("//mode:win_release"),
             (linux) = Target("//mode:linux_release"),
         }
     ),
     c = CcToolchain(
         compiler = select(
-            (host_platform, host_arch) => {
+            (build_platform, build_arch) => {
                 (windows, x64) = RelPath("llvm/x86_64-pc-windows-msvc/bin/clang.exe")
             }
         ),
         linker = select(
-            (host_platform, host_arch, target_platform) => {
+            (build_platform, build_arch, target_platform) => {
                 (windows, x64, windows) = RelPath("llvm/x86_64-pc-windows-msvc/bin/lld-link.exe"),
                 (windows, x64, linux) = RelPath("llvm/x86_64-pc-windows-msvc/bin/ld.lld.exe"),
             }
         ),
         archiver = select(
-            (host_platform, host_arch) => {
+            (build_platform, build_arch) => {
                 (windows, x64) = RelPath("llvm/x86_64-pc-windows-msvc/bin/llvm-ar.exe")
             }
         ),
@@ -152,7 +152,7 @@ toolchain(
             }
         ),
         defines = multi_select(
-            (target_platform, target_arch, host_platform, build_type) => {
+            (target_platform, target_arch, build_platform, build_type) => {
                 # debug/release
                 (_, _, _, debug) = ["_DEBUG"],
                 (_, _, _, release) = ["NDEBUG"],
@@ -188,18 +188,18 @@ toolchain(
     ),
     cpp = CcToolchain(
         compiler = select(
-            (host_platform, host_arch) => {
+            (build_platform, build_arch) => {
                 (windows, x64) = RelPath("llvm/x86_64-pc-windows-msvc/bin/clang++.exe")
             }
         ),
         linker = select(
-            (host_platform, host_arch, target_platform) => {
+            (build_platform, build_arch, target_platform) => {
                 (windows, x64, windows) = RelPath("llvm/x86_64-pc-windows-msvc/bin/lld-link.exe"),
                 (windows, x64, linux) = RelPath("llvm/x86_64-pc-windows-msvc/bin/ld.lld.exe"),
             }
         ),
         archiver = select(
-            (host_platform, host_arch) => {
+            (build_platform, build_arch) => {
                 (windows, x64) = RelPath("llvm/x86_64-pc-windows-msvc/bin/llvm-ar.exe")
             }
         ),
@@ -325,7 +325,7 @@ toolchain(
             }
         ),
         defines = multi_select(
-            (target_platform, target_arch, host_platform, build_type) => {
+            (target_platform, target_arch, build_platform, build_type) => {
                 # debug/release
                 (_, _, _, debug) = ["_DEBUG"],
                 (_, _, _, release) = ["NDEBUG"],
@@ -367,12 +367,12 @@ toolchain(
     ),
     nasm = NasmToolchain(
         assembler = select(
-            (host_platform, host_arch) => {
+            (build_platform, build_arch) => {
                 (windows, x64) = RelPath("nasm/win64/nasm.exe")
             }
         ),
         archiver = select(
-            (host_platform, host_arch) => {
+            (build_platform, build_arch) => {
                 (windows, x64) = RelPath("llvm/x86_64-pc-windows-msvc/bin/llvm-ar.exe")
             }
         ),
@@ -385,7 +385,7 @@ toolchain(
     ),
     zig = ZigToolchain(
         compiler = select(
-            (host_platform, host_arch) => {
+            (build_platform, build_arch) => {
                 (windows, x64) = RelPath("zig/0.15.2/bin/windows_x64/zig.exe"),
                 (linux, x64) = RelPath("zig/0.15.2/bin/linux_x64/zig"),
             }


### PR DESCRIPTION
## Summary
Renamed all `host_platform` and `host_arch` variables to `build_platform` and `build_arch` throughout the codebase for improved semantic clarity. The term "build" more accurately describes the platform and architecture where the build is occurring, distinguishing it from "target" (where the built artifacts will run).

## Key Changes
- **Variable naming**: Renamed `host_platform` → `build_platform` and `host_arch` → `build_arch` across all files
- **Struct fields**: Updated `Toolchain.host_mode` → `Toolchain.build_mode` to reflect the mode used for building tools on the build platform
- **Documentation**: Updated comments and documentation to use "build platform/architecture" terminology consistently
- **Configuration files**: Updated `toolchains/ANUBIS` and `CLAUDE.md` to reflect the new variable names in select expressions and mode definitions

## Files Modified
- `src/anubis.rs`: Variable injection logic
- `src/toolchain.rs`: Struct field and documentation
- `src/rules/cmd_rules.rs`: Build context variable names
- `toolchains/ANUBIS`: Toolchain configuration
- `CLAUDE.md`: Documentation
- `.claude/skills/anubis-windows-commands/SKILL.md`: Skill documentation
- `README.md`: Example code

## Implementation Details
The renaming is purely semantic with no functional changes. All references to the platform and architecture where the build is occurring now use the "build" prefix instead of "host", making the distinction between build platform and target platform clearer throughout the codebase.

https://claude.ai/code/session_013qHntrprYvFUyT2kpoiAKA