### PR TITLE
Remove library directory and library linking from CC toolchain args

### DIFF
--- a/src/rules/cc_rules.rs
+++ b/src/rules/cc_rules.rs
@@ -233,12 +233,6 @@ impl<'a> CcContextExt<'a> for Arc<JobContext> {
             args.push("-isystem".to_owned());
             args.push(inc_dir.to_string_lossy().into_owned());
         }
-        for lib_dir in &cc_toolchain.library_dirs {
-            args.push(format!("-L{}", &lib_dir.to_string_lossy()));
-        }
-        for lib in &cc_toolchain.libraries {
-            args.push(format!("-l{}", &lib.to_string_lossy()));
-        }
         for define in &cc_toolchain.defines {
             args.push(format!("-D{}", define));
         }


### PR DESCRIPTION
## Summary
Removed the automatic addition of library directories (`-L`) and library linking flags (`-l`) from the C/C++ compiler arguments in the CC toolchain context.

## Changes
- Removed loop that added `-L{lib_dir}` flags for each library directory in the toolchain
- Removed loop that added `-l{lib}` flags for each library in the toolchain
- Kept the include directory (`-isystem`) and define (`-D`) flag generation intact

## Rationale
This change decouples library linking from the automatic toolchain argument generation, likely to provide more explicit control over library linking at a higher level or to avoid unintended library dependencies being automatically linked. Library linking can now be managed separately through other mechanisms rather than being implicitly added from the toolchain configuration.

https://claude.ai/code/session_01WJtgfP1jDt8S87AGWYti6Z