### PR TITLE
Fix filter matching logic and zig build argument ordering

### DIFF
--- a/src/rules/zig_rules.rs
+++ b/src/rules/zig_rules.rs
@@ -133,12 +133,12 @@ fn build_zig_glibc(zig_glibc: Arc<ZigGlibc>, job: Job) -> anyhow::Result<JobOutc
         "--verbose-link".into(),
     ];
 
-    if !is_c {
+    if is_c {
+        args.push("-lc".into());
+    } else {
         args.push("-cflags".into());
         args.push("-std=c++20".into());
         args.push("--".into());
-        args.push("-lc".into());
-    } else {
         args.push("-lc++".into());
     }
 
@@ -151,7 +151,6 @@ fn build_zig_glibc(zig_glibc: Arc<ZigGlibc>, job: Job) -> anyhow::Result<JobOutc
     if output.status.success() {
         // zig emits all logs to stderr
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let lines = stderr.lines().rev();
 
         // find the final linker line
         let linker_cmd = stderr.lines().rev().find(|l| l.contains(dummy_bin_name)).ok_or_else(|| {


### PR DESCRIPTION
## Summary
This PR fixes two bugs: (1) a filter matching logic issue where default filters were being matched too early, preventing specific filters from being evaluated, and (2) incorrect conditional logic in zig build arguments that was inverting the C vs C++ compilation flags.

## Key Changes

- **Filter matching (papyrus.rs)**: Refactored the filter resolution to use a two-pass approach:
  - First pass: Check all specific (non-default) filters for matches
  - Second pass: Only use the default filter if no specific filters matched
  - This prevents the default case from short-circuiting the evaluation of more specific filters

- **Zig build arguments (zig_rules.rs)**: Fixed inverted conditional logic:
  - Changed `if !is_c` to `if is_c` to correctly apply C-specific flags
  - Reorganized the argument order so C builds use `-lc` and C++ builds use `-lc++` with proper `-cflags` wrapping
  - Removed unused variable `lines` that was created but never used

## Implementation Details

The filter matching fix ensures that when multiple filters are defined, the most specific matching filter is used rather than falling back to the default immediately. This is important for proper configuration resolution in complex build scenarios.

The zig build fix corrects the logic so that C and C++ compilation use the appropriate standard library linking flags and compiler flags.

https://claude.ai/code/session_01JQ22eAHSqZz3Y2vNGWXYCL